### PR TITLE
feat: Add version flag and package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ordis-cli",
   "version": "0.1.0",
+  "type": "module",
   "description": "Schema-first LLM extraction tool that turns unstructured text into validated structured data",
   "main": "dist/cli.js",
   "bin": {
@@ -36,6 +37,11 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "devDependencies": {
     "@types/node": "^24.10.2",
     "@vitest/ui": "^4.0.15",

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -32,6 +32,22 @@ describe('CLI', () => {
         });
     });
 
+    describe('version command', () => {
+        it('should display version with --version flag', async () => {
+            const { stdout } = await execAsync(`node ${CLI_PATH} --version`);
+            
+            expect(stdout).toContain('ordis-cli v');
+            expect(stdout).toMatch(/v\d+\.\d+\.\d+/);
+        });
+
+        it('should display version with -v flag', async () => {
+            const { stdout } = await execAsync(`node ${CLI_PATH} -v`);
+            
+            expect(stdout).toContain('ordis-cli v');
+            expect(stdout).toMatch(/v\d+\.\d+\.\d+/);
+        });
+    });
+
     describe('error handling', () => {
         it('should error when no command specified', async () => {
             try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import { loadSchema } from './schemas/loader.js';
 import { extract } from './core/pipeline.js';
 import type { LLMConfig } from './llm/types.js';
+import packageJson from '../package.json' with { type: 'json' };
 
 interface CliArgs {
     command?: string;
@@ -28,6 +29,11 @@ function parseArgs(args: string[]): CliArgs {
 
         if (arg === '--help' || arg === '-h') {
             showHelp();
+            process.exit(0);
+        }
+
+        if (arg === '--version' || arg === '-v') {
+            showVersion();
             process.exit(0);
         }
 
@@ -65,6 +71,7 @@ OPTIONS:
   --base <url>      Base URL for OpenAI-compatible API
   --model <name>    Model name to use for extraction
   --debug           Enable verbose debug output
+  --version, -v     Show version number
   --help, -h        Show this help message
 
 EXAMPLES:
@@ -80,6 +87,10 @@ EXAMPLES:
 
 For more information, visit: https://github.com/ordis-dev/ordis-cli
 `);
+}
+
+function showVersion(): void {
+    console.log(`ordis-cli v${packageJson.version}`);
 }
 
 async function runExtraction(args: CliArgs): Promise<void> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "node16",
+    "module": "nodenext",
     "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",
@@ -10,7 +10,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "moduleResolution": "node16",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true


### PR DESCRIPTION
## Summary

Implements Issue #15 - Add version flag to CLI and complete package.json metadata for npm publishing.

## Changes

- ✅ Add `--version` / `-v` flag to display version number
- ✅ Import package.json version dynamically using import attributes
- ✅ Add `files` field to package.json for npm publishing control
- ✅ Add `type: module` to package.json for proper ES module support
- ✅ Update tsconfig.json to use `nodenext` modules
- ✅ Update help text to include version flag
- ✅ Add tests for version flag (--version and -v)

## Testing

- All 150 tests passing (2 new version tests added)
- `ordis --version` displays: `ordis-cli v0.1.0`
- `ordis -v` works as shorthand
- Version matches package.json
- Help text updated with version flag
- Verified extraction still works correctly with real LLM

## Package.json Improvements

- Added `files` field to control what gets published to npm (dist, README, LICENSE)
- Added `type: module` for proper ES module support
- Engines field already present (Node.js >=18.0.0) from #11

## Resolves

Closes #15