### PR TITLE
feat: Add programmatic API for library usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ Ordis is a local-first CLI tool that turns messy, unstructured text into clean, 
 
 **✅ CLI functional** - Core extraction pipeline working with real LLMs. Ready for testing and feedback.
 
+**✅ Programmatic API** - Can be used as an npm package in Node.js applications.
+
 ## Features
 
 - **Local-first extraction**: Supports Ollama, LM Studio, or any OpenAI-compatible endpoint
 - **Schema-first workflow**: Define your data structure upfront
 - **Deterministic output**: Returns validated records or structured failures
-- **Minimal CLI**: Fast experimentation with simple commands
+- **Dual-purpose**: Use as CLI tool or import as library
+- **TypeScript support**: Full type definitions included
 
 ## Example
 
@@ -53,6 +56,8 @@ Works with any service exposing an OpenAI-compatible API:
 
 ## Installation
 
+### As a CLI Tool
+
 ```bash
 git clone https://github.com/ordis-dev/ordis-cli
 cd ordis-cli
@@ -66,6 +71,86 @@ Run the CLI:
 node dist/cli.js --help
 ```
 
+### As an npm Package
+
+```bash
+npm install ordis-cli
+```
+
+## Usage
+
+### CLI Usage
+
+Extract data from text using a schema:
+
+```bash
+ordis extract \
+  --schema examples/invoice.schema.json \
+  --input examples/invoice.txt \
+  --base http://localhost:11434/v1 \
+  --model llama3.1:8b \
+  --debug
+```
+
+### Programmatic Usage
+
+Use ordis-cli as a library in your Node.js application:
+
+```typescript
+import { extract, loadSchema, LLMClient } from 'ordis-cli';
+
+// Load schema from file
+const schema = await loadSchema('./invoice.schema.json');
+
+// Or create schema from object
+import { loadSchemaFromObject } from 'ordis-cli';
+const schema = loadSchemaFromObject({
+  fields: {
+    invoice_id: { type: 'string' },
+    amount: { type: 'number' },
+    currency: { type: 'string', enum: ['USD', 'EUR', 'SGD'] }
+  }
+});
+
+// Configure LLM
+const llmConfig = {
+  baseURL: 'http://localhost:11434/v1',
+  model: 'llama3.2:3b'
+};
+
+// Extract data
+const result = await extract({
+  input: 'Invoice #INV-2024-0042 for $1,250.00 USD',
+  schema,
+  llmConfig
+});
+
+if (result.success) {
+  console.log(result.data);
+  // { invoice_id: 'INV-2024-0042', amount: 1250, currency: 'USD' }
+  console.log('Confidence:', result.confidence);
+} else {
+  console.error('Extraction failed:', result.errors);
+}
+```
+
+**Using LLM Presets:**
+
+```typescript
+import { extract, loadSchema, LLMPresets } from 'ordis-cli';
+
+const schema = await loadSchema('./schema.json');
+
+// Use preset configurations
+const result = await extract({
+  input: text,
+  schema,
+  llmConfig: LLMPresets.ollama('llama3.2:3b')
+  // Or: LLMPresets.openai(apiKey, 'gpt-4o-mini')
+  // Or: LLMPresets.lmStudio('local-model')
+});
+```
+
 ## What Works
 
 - ✅ Schema loader and validator
@@ -73,7 +158,9 @@ node dist/cli.js --help
 - ✅ Universal LLM client (OpenAI-compatible APIs)
 - ✅ Structured error system
 - ✅ CLI extraction command
+- ✅ Programmatic API for library usage
 - ✅ Field-level confidence tracking
+- ✅ TypeScript type definitions
 
 ## Roadmap
 

--- a/package.json
+++ b/package.json
@@ -3,9 +3,16 @@
   "version": "0.1.0",
   "type": "module",
   "description": "Schema-first LLM extraction tool that turns unstructured text into validated structured data",
-  "main": "dist/cli.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "bin": {
     "ordis": "dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
   },
   "scripts": {
     "build": "tsc",

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for programmatic API imports
+ */
+
+import { describe, it, expect } from 'vitest';
+
+describe('Programmatic API', () => {
+    describe('Core exports', () => {
+        it('should export extract function', async () => {
+            const { extract } = await import('../index.js');
+            expect(extract).toBeDefined();
+            expect(typeof extract).toBe('function');
+        });
+
+        it('should export ExtractionPipeline class', async () => {
+            const { ExtractionPipeline } = await import('../index.js');
+            expect(ExtractionPipeline).toBeDefined();
+            expect(typeof ExtractionPipeline).toBe('function');
+        });
+
+        it('should export validateExtractedData', async () => {
+            const { validateExtractedData } = await import('../index.js');
+            expect(validateExtractedData).toBeDefined();
+            expect(typeof validateExtractedData).toBe('function');
+        });
+
+        it('should export PipelineError', async () => {
+            const { PipelineError, PipelineErrorCodes } = await import('../index.js');
+            expect(PipelineError).toBeDefined();
+            expect(PipelineErrorCodes).toBeDefined();
+        });
+    });
+
+    describe('Schema exports', () => {
+        it('should export loadSchema function', async () => {
+            const { loadSchema } = await import('../index.js');
+            expect(loadSchema).toBeDefined();
+            expect(typeof loadSchema).toBe('function');
+        });
+
+        it('should export parseSchema function', async () => {
+            const { parseSchema } = await import('../index.js');
+            expect(parseSchema).toBeDefined();
+            expect(typeof parseSchema).toBe('function');
+        });
+
+        it('should export validateSchema function', async () => {
+            const { validateSchema } = await import('../index.js');
+            expect(validateSchema).toBeDefined();
+            expect(typeof validateSchema).toBe('function');
+        });
+
+        it('should export SchemaValidationError', async () => {
+            const { SchemaValidationError, SchemaErrorCodes } = await import('../index.js');
+            expect(SchemaValidationError).toBeDefined();
+            expect(SchemaErrorCodes).toBeDefined();
+        });
+    });
+
+    describe('LLM exports', () => {
+        it('should export LLMClient class', async () => {
+            const { LLMClient } = await import('../index.js');
+            expect(LLMClient).toBeDefined();
+            expect(typeof LLMClient).toBe('function');
+        });
+
+        it('should export createLLMClient function', async () => {
+            const { createLLMClient } = await import('../index.js');
+            expect(createLLMClient).toBeDefined();
+            expect(typeof createLLMClient).toBe('function');
+        });
+
+        it('should export LLMPresets', async () => {
+            const { LLMPresets } = await import('../index.js');
+            expect(LLMPresets).toBeDefined();
+            expect(LLMPresets.ollama).toBeDefined();
+            expect(LLMPresets.lmStudio).toBeDefined();
+            expect(LLMPresets.openai).toBeDefined();
+        });
+
+        it('should export buildSystemPrompt function', async () => {
+            const { buildSystemPrompt } = await import('../index.js');
+            expect(buildSystemPrompt).toBeDefined();
+            expect(typeof buildSystemPrompt).toBe('function');
+        });
+
+        it('should export LLMError', async () => {
+            const { LLMError, LLMErrorCodes } = await import('../index.js');
+            expect(LLMError).toBeDefined();
+            expect(LLMErrorCodes).toBeDefined();
+        });
+    });
+
+    describe('End-to-end library usage', () => {
+        it('should support basic extraction workflow', async () => {
+            const { loadSchemaFromObject, extract } = await import('../index.js');
+
+            const schema = loadSchemaFromObject({
+                fields: {
+                    name: { type: 'string' },
+                    amount: { type: 'number' }
+                }
+            });
+
+            expect(schema).toBeDefined();
+            expect(schema.fields).toBeDefined();
+            expect(schema.fields.name).toBeDefined();
+            expect(schema.fields.amount).toBeDefined();
+        });
+    });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Ordis CLI - Public API
+ * Main entry point for programmatic usage
+ */
+
+// Core pipeline exports
+export { ExtractionPipeline, extract } from './core/pipeline.js';
+export { validateExtractedData } from './core/validator.js';
+export { PipelineError, PipelineErrorCodes } from './core/errors.js';
+export type {
+    PipelineConfig,
+    ExtractionRequest,
+    PipelineResult,
+    StepResult,
+} from './core/types.js';
+
+// Schema exports
+export { loadSchema, parseSchema, loadSchemaFromObject } from './schemas/loader.js';
+export { validateSchema } from './schemas/validator.js';
+export { SchemaValidationError, ErrorCodes as SchemaErrorCodes } from './schemas/errors.js';
+export type { 
+    Schema, 
+    FieldDefinition, 
+    FieldType, 
+    ValidationError, 
+    ValidationResult 
+} from './schemas/types.js';
+
+// LLM exports
+export { LLMClient, createLLMClient, LLMPresets } from './llm/client.js';
+export { LLMError, LLMErrorCodes } from './llm/errors.js';
+export { buildSystemPrompt, buildUserPrompt } from './llm/prompt-builder.js';
+export type {
+    LLMConfig,
+    RetryConfig,
+    ChatMessage,
+    LLMRequest,
+    LLMResponse,
+    ExtractionOptions,
+    ExtractionResponse,
+} from './llm/types.js';


### PR DESCRIPTION
## Summary

Implements Issue #23 - Enable ordis-cli to be used as an npm package with programmatic API.

## Changes

### Core Implementation
- ✅ Created `src/index.ts` as library entry point
- ✅ Export all public APIs: `extract`, `loadSchema`, `LLMClient`, etc.
- ✅ Export all types: `Schema`, `PipelineResult`, `LLMConfig`, etc.

### Package Configuration
- ✅ Updated `main` to point to `dist/index.js` (library)
- ✅ Added `types` field pointing to `dist/index.d.ts`
- ✅ Added `exports` field for modern Node.js
- ✅ Kept `bin` pointing to `dist/cli.js` (CLI still works)

### Documentation
- ✅ Added "Programmatic Usage" section to README
- ✅ Provided example code for library imports
- ✅ Documented LLMPresets usage
- ✅ Updated features and status

### Testing
- ✅ Added 14 new tests for API imports (`src/__tests__/api.test.ts`)
- ✅ Test all core exports (extract, ExtractionPipeline, etc.)
- ✅ Test all schema exports (loadSchema, validateSchema, etc.)
- ✅ Test all LLM exports (LLMClient, LLMPresets, etc.)
- ✅ Verified imports work correctly
- ✅ All 164 tests passing (14 new + 150 existing)

## Usage Examples

### Import and use
```typescript
import { extract, loadSchema, LLMPresets } from 'ordis-cli';

const schema = await loadSchema('./schema.json');
const result = await extract({
  input: 'Invoice #123,  USD',
  schema,
  llmConfig: LLMPresets.ollama('llama3.2:3b')
});
```

### CLI still works
```bash
ordis extract --schema schema.json --input data.txt
ordis --version  # ordis-cli v0.1.0
```

## Verification

- ✅ CLI functionality unchanged
- ✅ Library imports work correctly
- ✅ TypeScript types generated
- ✅ All tests passing
- ✅ README updated with examples

## Resolves

Closes #23