### PR TITLE
Simplify and clarify prompt instructions

### DIFF
--- a/src/llm/__tests__/prompt-builder.test.ts
+++ b/src/llm/__tests__/prompt-builder.test.ts
@@ -21,7 +21,7 @@ describe('Prompt Builder', () => {
             expect(prompt).toContain('data extraction');
             expect(prompt).toContain('name: string');
             expect(prompt).toContain('age: number');
-            expect(prompt).toContain('ONLY valid JSON');
+            expect(prompt).toContain('only valid JSON');
         });
 
         it('should include field descriptions', () => {
@@ -108,7 +108,7 @@ describe('Prompt Builder', () => {
             const prompt = buildSystemPrompt(schema);
 
             expect(prompt).toContain('threshold: 85%');
-            expect(prompt).toContain('per-field confidence');
+            expect(prompt).toContain('confidence score');
         });
 
         it('should include response format', () => {


### PR DESCRIPTION
Fixes #31

## Changes

### Prompt Simplification
- ✅ Removed ALLCAPS emphasis (CRITICAL, IMPORTANT)
- ✅ Consolidated redundant confidence instructions (mentioned once clearly)
- ✅ Replaced confusing placeholder syntax (`<extracted_value_or_null>`) with concrete examples
- ✅ Use 'null' text instead of infinity symbols (−∞, ∞)
- ✅ More specific role: 'structured data extraction system'
- ✅ Cleaner formatting with simple bullet points

### Example Improvements
- Response format now shows actual field names from schema
- Uses realistic example values (string, number) instead of abstract placeholders

## Before
```
CRITICAL INSTRUCTIONS:
1. Return ONLY valid JSON matching the schema
2. Include confidence scores (0-100) for each field, even if field is null
...
5. ALWAYS include ALL fields in confidenceByField, even if value is null

RESPONSE FORMAT:
{
  "data": {
    "name": <extracted_value_or_null>,
    "age": <extracted_value_or_null>
  },
  ...
}

IMPORTANT: Include ALL fields in both data and confidenceByField...
```

## After
```
Rules:
- Return only valid JSON (no markdown, no explanation)
- Include a confidence score (0-100) for each field
- Use null for missing or uncertain values
- Include all fields in the response, even if null

Response format:
{
  "data": {
    "name": "extracted value or null",
    "age": 42,
    ...
  },
  ...
}
```

## Testing
- ✅ All 164 tests pass
- ✅ Prompt builder tests updated
- ✅ Manual verification with example schemas shows cleaner output

## Benefits
- Easier for LLMs to parse and follow
- Less noise, more signal
- Concrete examples instead of abstract placeholders
- More professional, less shouty tone