### PR TITLE
Rename project from ordis-cli to @ordis-dev/ordis

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -55,7 +55,7 @@ body:
       placeholder: |
         - OS: macOS 14.0
         - Node.js: 18.17.0
-        - ordis-cli: 0.1.0
+        - @ordis-dev/ordis: 0.1.0
         - LLM provider: Ollama (llama3.1:8b)
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -14,7 +14,7 @@ body:
       label: Description
       description: Brief explanation of what needs to be done and why
       placeholder: |
-        Create the initial project structure for ordis-cli including:
+        Create the initial project structure for Ordis including:
         - TypeScript/Node.js setup
         - Basic CLI entrypoint
         - Project configuration files

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,8 +1,8 @@
-# Copilot Instructions for ordis-cli
+# Copilot Instructions for Ordis
 
 ## Project Overview
 
-**ordis-cli** is a CLI tool for extracting structured data from unstructured text using schema-first LLM pipelines. The project emphasizes deterministic, validated output over "close enough" results.
+**Ordis** is a tool and library for extracting structured data from unstructured text using schema-first LLM pipelines. The project emphasizes deterministic, validated output over "close enough" results.
 
 ### Core Principles
 

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,29 @@
+# Source files (we publish dist/ only)
+src/
+benchmarks/
+examples/
+
+# Development files
+*.test.ts
+*.spec.ts
+*.bench.ts
+__tests__/
+.github/
+docs/
+
+# Config files
+tsconfig.json
+vitest.config.ts
+.env
+.env.*
+
+# Build artifacts
+*.tsbuildinfo
+
+# IDE
+.vscode/
+.idea/
+
+# Misc
+*.log
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2025-12-18
+
+### Added
+- Initial release of @ordis-dev/ordis
+- Schema-first extraction engine with validation
+- OpenAI-compatible LLM client support (Ollama, LM Studio, OpenRouter, etc.)
+- CLI tool for processing text files with JSON schemas
+- Programmatic API for library usage
+- TypeScript support with full type definitions
+- Confidence scoring for extracted data
+- Token budget management
+- Comprehensive test suite
+- Benchmark suite for model comparison
+- Example schemas and input files
+
+[Unreleased]: https://github.com/ordis-dev/ordis/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/ordis-dev/ordis/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Ordis CLI
+# Ordis
 
-Ordis is a local-first CLI tool that turns messy, unstructured text into clean, structured data using a schema-driven extraction pipeline powered by LLMs. You give it a schema that describes the fields you expect, point it at some raw text, and choose any OpenAI-compatible model. Ordis builds the prompt, calls the model, validates the output, and returns either a correct structured record or a clear error.
+Ordis is a local-first tool and library that turns messy, unstructured text into clean, structured data using a schema-driven extraction pipeline powered by LLMs. You give it a schema that describes the fields you expect, point it at some raw text, and choose any OpenAI-compatible model. Ordis builds the prompt, calls the model, validates the output, and returns either a correct structured record or a clear error.
 
 **Ordis does for LLM extraction what Prisma does for databases: strict schemas, predictable output and no more glue code.**
 
@@ -16,7 +16,7 @@ Ordis is a local-first CLI tool that turns messy, unstructured text into clean, 
 - **Schema-first workflow**: Define your data structure upfront
 - **Deterministic output**: Returns validated records or structured failures
 - **Token budget awareness**: Automatic token counting with warnings and limits
-- **Dual-purpose**: Use as CLI tool or import as library
+- **Dual-purpose**: Use as a CLI or import as a library
 - **TypeScript support**: Full type definitions included
 
 ## Example
@@ -57,25 +57,29 @@ Works with any service exposing an OpenAI-compatible API:
 
 ## Installation
 
-### As a CLI Tool
+### From npm (recommended)
+
+Install globally to use the CLI anywhere:
 
 ```bash
-git clone https://github.com/ordis-dev/ordis-cli
-cd ordis-cli
+npm install -g @ordis-dev/ordis
+ordis --help
+```
+
+Or install locally in your project:
+
+```bash
+npm install @ordis-dev/ordis
+```
+
+### From Source
+
+```bash
+git clone https://github.com/ordis-dev/ordis
+cd ordis
 npm install
 npm run build
-```
-
-Run the CLI:
-
-```bash
 node dist/cli.js --help
-```
-
-### As an npm Package
-
-```bash
-npm install ordis-cli
 ```
 
 ## Usage
@@ -95,10 +99,10 @@ ordis extract \
 
 ### Programmatic Usage
 
-Use ordis-cli as a library in your Node.js application:
+Use ordis as a library in your Node.js application:
 
 ```typescript
-import { extract, loadSchema, LLMClient } from 'ordis-cli';
+import { extract, loadSchema, LLMClient } from '@ordis-dev/ordis';
 
 // Load schema from file
 const schema = await loadSchema('./invoice.schema.json');
@@ -138,7 +142,7 @@ if (result.success) {
 **Using LLM Presets:**
 
 ```typescript
-import { extract, loadSchema, LLMPresets } from 'ordis-cli';
+import { extract, loadSchema, LLMPresets } from '@ordis-dev/ordis';
 
 const schema = await loadSchema('./schema.json');
 
@@ -175,13 +179,13 @@ npm run benchmark
 ```
 
 ## Roadmap
-Smart input truncation ([#40](https://github.com/ordis-dev/ordis-cli/issues/40))
-- [ ] Multi-pass extraction for large inputs ([#41](https://github.com/ordis-dev/ordis-cli/issues/41))
+Smart input truncation ([#40](https://github.com/ordis-dev/ordis/issues/40))
+- [ ] Multi-pass extraction for large inputs ([#41](https://github.com/ordis-dev/ordis/issues/41))
 - [ ] 
-- [ ] Config file support ([#16](https://github.com/ordis-dev/ordis-cli/issues/16))
-- [ ] Output formatting options ([#14](https://github.com/ordis-dev/ordis-cli/issues/14))
-- [ ] Batch extraction ([#19](https://github.com/ordis-dev/ordis-cli/issues/19))
-- [ ] More example schemas ([#13](https://github.com/ordis-dev/ordis-cli/issues/13))
+- [ ] Config file support ([#16](https://github.com/ordis-dev/ordis/issues/16))
+- [ ] Output formatting options ([#14](https://github.com/ordis-dev/ordis/issues/14))
+- [ ] Batch extraction ([#19](https://github.com/ordis-dev/ordis/issues/19))
+- [ ] More example schemas ([#13](https://github.com/ordis-dev/ordis/issues/13))
 
 ## Contributing
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,6 @@
 # Performance Benchmarks
 
-This directory contains performance benchmarks for ordis-cli to measure extraction speed and identify bottlenecks.
+This directory contains performance benchmarks for Ordis to measure extraction speed and identify bottlenecks.
 
 ## Running Benchmarks
 

--- a/benchmarks/runner.ts
+++ b/benchmarks/runner.ts
@@ -15,7 +15,7 @@ const benchmarkFiles = readdirSync(benchmarksDir)
     .sort();
 
 console.log('╔═══════════════════════════════════════════════════════╗');
-console.log('║         Ordis CLI Performance Benchmarks             ║');
+console.log('║         Ordis Performance Benchmarks                 ║');
 console.log('╚═══════════════════════════════════════════════════════╝\n');
 
 for (const file of benchmarkFiles) {
@@ -28,7 +28,8 @@ for (const file of benchmarkFiles) {
         
         execSync(`npx tsx ${benchmarkPath}`, { stdio: 'inherit' });
     } catch (error) {
-        console.error(`\n❌ Error running ${file}:`, error.message);
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`\n❌ Error running ${file}:`, message);
     }
 }
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to ordis-cli
+# Contributing to Ordis
 
 Thank you for your interest in contributing! This document outlines how to contribute to this project.
 
@@ -12,8 +12,8 @@ Thank you for your interest in contributing! This document outlines how to contr
 ### Setup
 
 ```bash
-git clone https://github.com/ordis-dev/ordis-cli
-cd ordis-cli
+git clone https://github.com/ordis-dev/ordis
+cd ordis
 npm install
 npm run build
 ```

--- a/docs/confidence-scoring.md
+++ b/docs/confidence-scoring.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Confidence scoring is a core design principle in ordis-cli that allows users to define acceptable levels of certainty for LLM-based data extraction. Rather than accepting any extraction result, users can specify confidence thresholds to ensure data quality meets their requirements.
+Confidence scoring is a core design principle in Ordis that allows users to define acceptable levels of certainty for LLM-based data extraction. Rather than accepting any extraction result, users can specify confidence thresholds to ensure data quality meets their requirements.
 
 ## Core Principle
 
@@ -214,7 +214,7 @@ A 75% confident extraction might be:
 - ❌ Unacceptable for processing invoices
 - ⚠️ Useful with manual review for legal contracts
 
-By making confidence explicit and configurable, ordis-cli puts users in control of the quality-throughput tradeoff rather than making that decision for them.
+By making confidence explicit and configurable, Ordis puts users in control of the quality-throughput tradeoff rather than making that decision for them.
 
 ## Future Enhancements
 

--- a/docs/token-budget.md
+++ b/docs/token-budget.md
@@ -18,7 +18,7 @@ Token budget awareness prevents context overflow by tracking token usage and pro
 Token counting is automatic - no changes needed to existing code:
 
 ```typescript
-import { LLMClient } from 'ordis-cli';
+import { LLMClient } from '@ordis-dev/ordis';
 
 const client = new LLMClient({
     baseURL: 'http://localhost:11434/v1',
@@ -135,7 +135,7 @@ When approaching limits (default: ≥90%):
 Use token counting without LLMClient:
 
 ```typescript
-import { TokenCounter, estimateTokens } from 'ordis-cli';
+import { TokenCounter, estimateTokens } from '@ordis-dev/ordis';
 
 // Estimate tokens for text
 const tokens = estimateTokens('Hello, world!');

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ordis-cli",
+  "name": "@ordis-dev/ordis",
   "version": "0.1.0",
   "type": "module",
   "description": "Schema-first LLM extraction tool that turns unstructured text into validated structured data",
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ordis-dev/ordis-cli.git"
+    "url": "git+https://github.com/ordis-dev/ordis.git"
   },
   "keywords": [
     "llm",
@@ -39,9 +39,9 @@
   "author": "Ordis",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/ordis-dev/ordis-cli/issues"
+    "url": "https://github.com/ordis-dev/ordis/issues"
   },
-  "homepage": "https://github.com/ordis-dev/ordis-cli#readme",
+  "homepage": "https://github.com/ordis-dev/ordis#readme",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -16,7 +16,7 @@ describe('CLI', () => {
         it('should display help with --help flag', async () => {
             const { stdout } = await execAsync(`node ${CLI_PATH} --help`);
             
-            expect(stdout).toContain('Ordis CLI');
+            expect(stdout).toContain('Ordis');
             expect(stdout).toContain('USAGE:');
             expect(stdout).toContain('ordis extract');
             expect(stdout).toContain('--schema');
@@ -28,7 +28,7 @@ describe('CLI', () => {
         it('should display help with -h flag', async () => {
             const { stdout } = await execAsync(`node ${CLI_PATH} -h`);
             
-            expect(stdout).toContain('Ordis CLI');
+            expect(stdout).toContain('Ordis');
         });
     });
 
@@ -36,14 +36,14 @@ describe('CLI', () => {
         it('should display version with --version flag', async () => {
             const { stdout } = await execAsync(`node ${CLI_PATH} --version`);
             
-            expect(stdout).toContain('ordis-cli v');
+            expect(stdout).toContain('ordis v');
             expect(stdout).toMatch(/v\d+\.\d+\.\d+/);
         });
 
         it('should display version with -v flag', async () => {
             const { stdout } = await execAsync(`node ${CLI_PATH} -v`);
             
-            expect(stdout).toContain('ordis-cli v');
+            expect(stdout).toContain('ordis v');
             expect(stdout).toMatch(/v\d+\.\d+\.\d+/);
         });
     });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 /**
- * Ordis CLI - Schema-first extraction tool
- * Entrypoint for the command-line interface
+ * Ordis - Schema-first extraction tool
+ * CLI entrypoint
  */
 
 import * as fs from 'fs/promises';
@@ -60,7 +60,7 @@ function parseArgs(args: string[]): CliArgs {
 
 function showHelp(): void {
     console.log(`
-Ordis CLI - Schema-first LLM extraction tool
+Ordis - Schema-first LLM extraction tool
 
 USAGE:
   ordis extract [OPTIONS]
@@ -85,12 +85,12 @@ EXAMPLES:
   # Extract with debug output
   ordis extract --schema schema.json --input data.txt --debug
 
-For more information, visit: https://github.com/ordis-dev/ordis-cli
+For more information, visit: https://github.com/ordis-dev/ordis
 `);
 }
 
 function showVersion(): void {
-    console.log(`ordis-cli v${packageJson.version}`);
+    console.log(`ordis v${packageJson.version}`);
 }
 
 async function runExtraction(args: CliArgs): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Ordis CLI - Public API
+ * Ordis - Public API
  * Main entry point for programmatic usage
  */
 

--- a/src/schemas/types.ts
+++ b/src/schemas/types.ts
@@ -1,5 +1,5 @@
 /**
- * Schema type definitions for ordis-cli
+ * Schema type definitions for Ordis
  * 
  * Defines the structure and types used for schema validation.
  */


### PR DESCRIPTION
## Summary
Renames the project from ordis-cli to @ordis-dev/ordis for initial npm release as a scoped package.

## Related Issue
Fixes #44

## Changes
- [x] Update package name to @ordis-dev/ordis for npm scoped package
- [x] Rename all references from 'ordis-cli' to 'Ordis' in docs and code
- [x] Update repository URLs to ordis-dev/ordis organization
- [x] Add .npmignore to exclude dev files from npm package
- [x] Add CHANGELOG.md for v0.1.0 release tracking
- [x] Update CLI branding and help text
- [x] Fix error message type assertion in benchmark runner

## Testing
- [x] Project builds successfully (`npm run build`)
- [x] All existing functionality still works (188 tests passing)
- [x] CLI help and examples are accurate

## Type of Change
- [x] Breaking change (package name change requires users to reinstall)
- [x] Documentation update

## Documentation
- [x] Updated README with correct package name and install instructions
- [x] Updated docs/ files for consistency
- [x] Added CHANGELOG.md for release tracking
- [x] Updated CLI help text