### PR TITLE
feat: add --api-key CLI option for API authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ ordis extract \
   --debug
 ```
 
+**With API key** (for providers like OpenAI, Deepseek, etc.):
+
+```bash
+ordis extract \
+  --schema examples/invoice.schema.json \
+  --input examples/invoice.txt \
+  --base https://api.deepseek.com/v1 \
+  --model deepseek-chat \
+  --api-key your-api-key-here
+```
+
 ### Programmatic Usage
 
 Use ordis as a library in your Node.js application:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ interface CliArgs {
     input?: string;
     base?: string;
     model?: string;
+    apiKey?: string;
     debug?: boolean;
 }
 
@@ -50,6 +51,8 @@ function parseArgs(args: string[]): CliArgs {
             parsed.base = args[++i];
         } else if (arg === '--model' && args[i + 1]) {
             parsed.model = args[++i];
+        } else if (arg === '--api-key' && args[i + 1]) {
+            parsed.apiKey = args[++i];
         } else if (!arg.startsWith('--')) {
             parsed.command = arg;
         }
@@ -70,6 +73,7 @@ OPTIONS:
   --input <path>    Path to input text file
   --base <url>      Base URL for OpenAI-compatible API
   --model <name>    Model name to use for extraction
+  --api-key <key>   API key for the LLM provider (optional)
   --debug           Enable verbose debug output
   --version, -v     Show version number
   --help, -h        Show this help message
@@ -152,6 +156,7 @@ async function runExtraction(args: CliArgs): Promise<void> {
         const llmConfig: LLMConfig = {
             baseURL: args.base,
             model: args.model,
+            ...(args.apiKey && { apiKey: args.apiKey }),
         };
 
         if (args.debug) {


### PR DESCRIPTION
## Summary
Add "--api-key=value" to CLI params to send with request to LLM. Especially useful for external providers like OpenAI, DeepSeek, etc.

## Related Issue
-

## Changes
- [x] Add --api-key argument parsing in CLI
- [x] Pass apiKey to LLMConfig when provided
- [x] Update help text to document --api-key option
- [x] Add README example showing usage with API providers
- [x] Enables use with OpenAI, Deepseek, and other authenticated APIs

## Testing
- [ ] Project builds successfully (`npm run build`)
- [ ] All existing functionality still works
- [x] New features work as expected
- [x] CLI help and examples are accurate

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Hotfix (urgent production fix)

## Documentation
- [x] Updated README if needed
- [ ] Updated docs/ files if needed
- [ ] Added/updated code comments for complex logic
- [x] Updated CLI help text if commands changed