### PR TITLE
fix: accept maxContextTokens as top-level parameter in extract()

### DIFF
--- a/src/core/pipeline.ts
+++ b/src/core/pipeline.ts
@@ -41,8 +41,13 @@ export class ExtractionPipeline {
             }
 
             // Step 1: Create LLM client
+            // Merge top-level maxContextTokens into llmConfig (top-level takes precedence)
+            const mergedLLMConfig = request.maxContextTokens
+                ? { ...request.llmConfig, maxContextTokens: request.maxContextTokens }
+                : request.llmConfig;
+
             const clientStep = this.recordStep('create_client', () => {
-                return new LLMClient(request.llmConfig);
+                return new LLMClient(mergedLLMConfig);
             });
             steps.push(clientStep);
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -46,6 +46,8 @@ export interface ExtractionRequest {
     llmConfig: LLMConfig;
     /** Optional preprocessing configuration */
     preprocessing?: PreprocessingConfig;
+    /** Maximum context tokens (overrides llmConfig.maxContextTokens) */
+    maxContextTokens?: number;
     debug?: boolean;
 }
 


### PR DESCRIPTION
## Summary
Fixes #67 - `maxContextTokens` was ignored when passed as a top-level parameter to `extract()`.

## Changes
- Add `maxContextTokens` to `ExtractionRequest` interface in `src/core/types.ts`
- Merge top-level `maxContextTokens` into `llmConfig` before creating `LLMClient` (top-level takes precedence)
- Add 3 tests verifying both top-level and nested parameter patterns work

## Usage
Both patterns now work:

```typescript
// Top-level (now works)
await extract({
  input: text,
  schema,
  llmConfig: { model: 'deepseek-r1:14b-32k', baseURL: '...' },
  maxContextTokens: 32768,
})

// Nested (still works)
await extract({
  input: text,
  schema,
  llmConfig: { model: 'deepseek-r1:14b-32k', baseURL: '...', maxContextTokens: 32768 },
})
```

## Testing
- All 252 tests pass
- Added 3 new tests for `maxContextTokens` parameter handling