### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-01-12
+
+### Fixed
+- `maxContextTokens` now works as a top-level parameter in `extract()` ([#67](https://github.com/ordis-dev/ordis/issues/67))
+  - Previously, the parameter was ignored unless passed inside `llmConfig`
+  - Top-level `maxContextTokens` now takes precedence over `llmConfig.maxContextTokens`
+  - Both usage patterns are supported for backwards compatibility
+
 ## [0.4.0] - 2026-01-12
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ordis-dev/ordis",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ordis-dev/ordis",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "node-html-parser": "^7.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordis-dev/ordis",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "Schema-first LLM extraction tool that turns unstructured text into validated structured data",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.4.1

### Fixed
- `maxContextTokens` now works as a top-level parameter in `extract()` (#67)

Closes #67