### PR TITLE
feat: Type coercion, date normalization, and array-of-objects support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-01-12
+
+### Added
+- **Type coercion for LLM output** ([#71](https://github.com/ordis-dev/ordis/issues/71))
+  - Automatic coercion of string numbers ("123" → 123)
+  - String boolean coercion ("true"/"yes"/"1" → true)
+  - Null-like string handling ("null"/"none"/"n/a" → null for optional fields)
+  - Coercion warnings in pipeline results for transparency
+  - New exports: `coerceValue()`, `coerceExtractedData()`, `coerceEnumValue()`, `coerceDateValue()`
+
+- **Enum case-insensitive coercion**
+  - "Series B" → "series_b" automatic normalization
+  - Space and hyphen to underscore conversion
+  - Case-insensitive matching against schema enum values
+
+- **Date format coercion**
+  - US format: "11/20/24" or "11/20/2024" → "2024-11-20"
+  - European format: "20-11-2024" or "20.11.2024" → "2024-11-20"
+  - Written format: "January 15, 2024" or "15 Jan 2024" → "2024-01-15"
+  - ISO with time stripping: "2024-01-15T10:00:00" → "2024-01-15"
+  - Requires `format: "date"` or `format: "date-time"` in schema
+
+- **Array of objects support** ([#70](https://github.com/ordis-dev/ordis/issues/70))
+  - New field type: `type: "array"` with `items: { type: "object", properties: {...} }`
+  - New field type: `type: "object"` with `properties: {...}` for nested objects
+  - Recursive validation with proper error paths (e.g., "items[1].price")
+  - Recursive coercion for nested field values
+  - Prompt builder generates nested schema descriptions for LLMs
+
+- **Ollama runtime options**
+  - `ollamaOptions.num_ctx` for dynamic context window sizing
+  - `ollamaOptions.num_gpu` for GPU layer control
+  - Pass Ollama-specific parameters without custom Modelfiles
+
+- **New example**: `08-funding-rounds-complex` demonstrating array-of-objects extraction
+
+### Changed
+- Prompt builder adds array-specific instructions when schema contains array fields
+- Benchmark now uses deep equality for array/object comparisons
+- Benchmark displays full JSON for array field comparisons (instead of "[object Object]")
+
+### Fixed
+- Array fields now properly validated with nested object structure
+- Coercion applied recursively to array items and nested objects
+
 ## [0.4.1] - 2026-01-12
 
 ### Fixed
@@ -67,6 +112,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Benchmark suite for model comparison
 - Example schemas and input files
 
-[Unreleased]: https://github.com/ordis-dev/ordis/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/ordis-dev/ordis/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/ordis-dev/ordis/compare/v0.4.1...v0.5.0
+[0.4.1]: https://github.com/ordis-dev/ordis/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/ordis-dev/ordis/compare/v0.1.0...v0.4.0
 [0.1.0]: https://github.com/ordis-dev/ordis/releases/tag/v0.1.0

--- a/examples/08-funding-rounds-complex.expected.json
+++ b/examples/08-funding-rounds-complex.expected.json
@@ -1,0 +1,42 @@
+{
+  "company_name": "TechStartup Inc",
+  "total_funding_usd": 78000000,
+  "funding_rounds": [
+    {
+      "round_type": "seed",
+      "amount_usd": 3000000,
+      "lead_investor": null,
+      "date": "2023-01-01"
+    },
+    {
+      "round_type": "series_a",
+      "amount_usd": 15000000,
+      "lead_investor": "Andreessen Horowitz",
+      "date": "2024-06-01"
+    },
+    {
+      "round_type": "series_b",
+      "amount_usd": 60000000,
+      "lead_investor": "Sequoia Capital",
+      "date": "2026-01-12"
+    }
+  ],
+  "key_investors": [
+    {
+      "name": "Sequoia Capital",
+      "type": "vc"
+    },
+    {
+      "name": "Andreessen Horowitz",
+      "type": "vc"
+    },
+    {
+      "name": "First Round Capital",
+      "type": "vc"
+    },
+    {
+      "name": "Tiger Global Management",
+      "type": "vc"
+    }
+  ]
+}

--- a/examples/08-funding-rounds-complex.schema.json
+++ b/examples/08-funding-rounds-complex.schema.json
@@ -1,0 +1,69 @@
+{
+  "fields": {
+    "company_name": {
+      "type": "string",
+      "description": "Name of the company"
+    },
+    "total_funding_usd": {
+      "type": "number",
+      "description": "Total funding raised in USD",
+      "optional": true
+    },
+    "funding_rounds": {
+      "type": "array",
+      "description": "List of funding rounds mentioned in the document",
+      "optional": true,
+      "items": {
+        "type": "object",
+        "properties": {
+          "round_type": {
+            "type": "string",
+            "description": "Type of funding round",
+            "enum": ["pre_seed", "seed", "series_a", "series_b", "series_c", "series_d", "other"]
+          },
+          "amount_usd": {
+            "type": "number",
+            "description": "Amount raised in USD",
+            "optional": true
+          },
+          "lead_investor": {
+            "type": "string",
+            "description": "Lead investor for this round",
+            "optional": true
+          },
+          "date": {
+            "type": "string",
+            "description": "Date of the funding round (ISO format)",
+            "format": "date",
+            "optional": true
+          }
+        }
+      }
+    },
+    "key_investors": {
+      "type": "array",
+      "description": "List of notable investors",
+      "optional": true,
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Investor name"
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of investor",
+            "enum": ["vc", "angel", "corporate", "other"],
+            "optional": true
+          }
+        }
+      }
+    }
+  },
+  "metadata": {
+    "name": "Funding Rounds Schema",
+    "version": "1.0.0",
+    "description": "Extract funding round information from startup news articles"
+  }
+}

--- a/examples/08-funding-rounds-complex.txt
+++ b/examples/08-funding-rounds-complex.txt
@@ -1,0 +1,14 @@
+TechStartup Inc Raises $60M in Series B Funding
+
+SAN FRANCISCO, January 12, 2026 — TechStartup Inc, a leading provider of AI-powered analytics solutions, today announced the close of its $60 million Series B funding round led by Sequoia Capital.
+
+The round also saw participation from existing investors Andreessen Horowitz and First Round Capital, along with new investor Tiger Global Management.
+
+"This funding will accelerate our product development and global expansion," said Jane Smith, CEO of TechStartup Inc. "We've grown 300% year-over-year and this investment validates our vision."
+
+This Series B follows the company's $15 million Series A round in June 2024, which was led by Andreessen Horowitz. Prior to that, TechStartup raised a $3 million seed round in early 2023 from a consortium of angel investors including prominent tech executives.
+
+In total, TechStartup Inc has now raised $78 million since its founding in 2022. The company plans to use the funds to expand its engineering team and enter new markets in Europe and Asia.
+
+About TechStartup Inc:
+Founded in 2022, TechStartup Inc provides enterprise analytics solutions powered by artificial intelligence. The company is headquartered in San Francisco with offices in New York and London.

--- a/src/core/__tests__/array-object.test.ts
+++ b/src/core/__tests__/array-object.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Tests for array and object type support
+ */
+
+import { describe, it, expect } from 'vitest';
+import { validateSchema } from '../../schemas/validator.js';
+import { validateExtractedData } from '../validator.js';
+import { buildSystemPrompt } from '../../llm/prompt-builder.js';
+import type { Schema } from '../../schemas/types.js';
+
+describe('Array and Object Type Support', () => {
+    describe('Schema Validation', () => {
+        it('should validate schema with array of objects', () => {
+            const schema = {
+                fields: {
+                    funding_rounds: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                round_type: { type: 'string' },
+                                amount_usd: { type: 'number', optional: true },
+                            },
+                        },
+                        optional: true,
+                    },
+                },
+            };
+
+            expect(() => validateSchema(schema)).not.toThrow();
+        });
+
+        it('should validate schema with nested object', () => {
+            const schema = {
+                fields: {
+                    address: {
+                        type: 'object',
+                        properties: {
+                            street: { type: 'string' },
+                            city: { type: 'string' },
+                            zip: { type: 'string', optional: true },
+                        },
+                    },
+                },
+            };
+
+            expect(() => validateSchema(schema)).not.toThrow();
+        });
+
+        it('should reject array without items', () => {
+            const schema = {
+                fields: {
+                    items: {
+                        type: 'array',
+                    },
+                },
+            };
+
+            expect(() => validateSchema(schema)).toThrow(/must have an 'items' property/);
+        });
+
+        it('should reject array with non-object items', () => {
+            const schema = {
+                fields: {
+                    items: {
+                        type: 'array',
+                        items: {
+                            type: 'string',
+                        },
+                    },
+                },
+            };
+
+            expect(() => validateSchema(schema)).toThrow(/items type must be 'object'/);
+        });
+
+        it('should reject object without properties', () => {
+            const schema = {
+                fields: {
+                    address: {
+                        type: 'object',
+                    },
+                },
+            };
+
+            expect(() => validateSchema(schema)).toThrow(/must have a 'properties' property/);
+        });
+
+        it('should validate nested property types', () => {
+            const schema = {
+                fields: {
+                    items: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                name: { type: 'invalid_type' },
+                            },
+                        },
+                    },
+                },
+            };
+
+            expect(() => validateSchema(schema)).toThrow(/invalid type/);
+        });
+    });
+
+    describe('Data Validation', () => {
+        it('should validate array of objects', () => {
+            const schema: Schema = {
+                fields: {
+                    funding_rounds: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                round_type: { type: 'string' },
+                                amount_usd: { type: 'number' },
+                            },
+                        },
+                    },
+                },
+            };
+
+            const validData = {
+                funding_rounds: [
+                    { round_type: 'series_a', amount_usd: 15000000 },
+                    { round_type: 'series_b', amount_usd: 45000000 },
+                ],
+            };
+
+            const result = validateExtractedData(validData, schema);
+            expect(result.valid).toBe(true);
+            expect(result.errors).toHaveLength(0);
+        });
+
+        it('should detect invalid item in array', () => {
+            const schema: Schema = {
+                fields: {
+                    items: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                name: { type: 'string' },
+                                price: { type: 'number' },
+                            },
+                        },
+                    },
+                },
+            };
+
+            const invalidData = {
+                items: [
+                    { name: 'Product A', price: 100 },
+                    { name: 'Product B', price: 'invalid' }, // Wrong type
+                ],
+            };
+
+            const result = validateExtractedData(invalidData, schema);
+            expect(result.valid).toBe(false);
+            expect(result.errors).toHaveLength(1);
+            expect(result.errors[0].field).toBe('items[1].price');
+            expect(result.errors[0].code).toBe('TYPE_MISMATCH');
+        });
+
+        it('should detect missing required field in array item', () => {
+            const schema: Schema = {
+                fields: {
+                    items: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                name: { type: 'string' },
+                                price: { type: 'number' },
+                            },
+                        },
+                    },
+                },
+            };
+
+            const invalidData = {
+                items: [
+                    { name: 'Product A', price: 100 },
+                    { name: 'Product B' }, // Missing price
+                ],
+            };
+
+            const result = validateExtractedData(invalidData, schema);
+            expect(result.valid).toBe(false);
+            expect(result.errors[0].field).toBe('items[1].price');
+            expect(result.errors[0].code).toBe('FIELD_MISSING');
+        });
+
+        it('should allow optional fields in array items', () => {
+            const schema: Schema = {
+                fields: {
+                    items: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                name: { type: 'string' },
+                                price: { type: 'number', optional: true },
+                            },
+                        },
+                    },
+                },
+            };
+
+            const validData = {
+                items: [
+                    { name: 'Product A', price: 100 },
+                    { name: 'Product B' }, // price is optional
+                ],
+            };
+
+            const result = validateExtractedData(validData, schema);
+            expect(result.valid).toBe(true);
+        });
+
+        it('should validate nested object', () => {
+            const schema: Schema = {
+                fields: {
+                    address: {
+                        type: 'object',
+                        properties: {
+                            street: { type: 'string' },
+                            city: { type: 'string' },
+                        },
+                    },
+                },
+            };
+
+            const validData = {
+                address: {
+                    street: '123 Main St',
+                    city: 'Springfield',
+                },
+            };
+
+            const result = validateExtractedData(validData, schema);
+            expect(result.valid).toBe(true);
+        });
+
+        it('should detect type mismatch in nested object', () => {
+            const schema: Schema = {
+                fields: {
+                    address: {
+                        type: 'object',
+                        properties: {
+                            street: { type: 'string' },
+                            zip: { type: 'number' },
+                        },
+                    },
+                },
+            };
+
+            const invalidData = {
+                address: {
+                    street: '123 Main St',
+                    zip: 'not-a-number',
+                },
+            };
+
+            const result = validateExtractedData(invalidData, schema);
+            expect(result.valid).toBe(false);
+            expect(result.errors[0].field).toBe('address.zip');
+        });
+
+        it('should handle empty array', () => {
+            const schema: Schema = {
+                fields: {
+                    items: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                name: { type: 'string' },
+                            },
+                        },
+                    },
+                },
+            };
+
+            const validData = {
+                items: [],
+            };
+
+            const result = validateExtractedData(validData, schema);
+            expect(result.valid).toBe(true);
+        });
+
+        it('should reject non-array value for array field', () => {
+            const schema: Schema = {
+                fields: {
+                    items: {
+                        type: 'array',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                name: { type: 'string' },
+                            },
+                        },
+                    },
+                },
+            };
+
+            const invalidData = {
+                items: { name: 'Not an array' },
+            };
+
+            const result = validateExtractedData(invalidData, schema);
+            expect(result.valid).toBe(false);
+            expect(result.errors[0].code).toBe('TYPE_MISMATCH');
+        });
+
+        it('should reject non-object value for object field', () => {
+            const schema: Schema = {
+                fields: {
+                    address: {
+                        type: 'object',
+                        properties: {
+                            street: { type: 'string' },
+                        },
+                    },
+                },
+            };
+
+            const invalidData = {
+                address: 'Not an object',
+            };
+
+            const result = validateExtractedData(invalidData, schema);
+            expect(result.valid).toBe(false);
+            expect(result.errors[0].code).toBe('TYPE_MISMATCH');
+        });
+    });
+
+    describe('Prompt Generation', () => {
+        it('should generate prompt for array of objects', () => {
+            const schema: Schema = {
+                fields: {
+                    funding_rounds: {
+                        type: 'array',
+                        description: 'List of funding rounds',
+                        items: {
+                            type: 'object',
+                            properties: {
+                                round_type: { 
+                                    type: 'string',
+                                    enum: ['seed', 'series_a', 'series_b'],
+                                },
+                                amount_usd: { type: 'number', optional: true },
+                            },
+                        },
+                        optional: true,
+                    },
+                },
+            };
+
+            const prompt = buildSystemPrompt(schema);
+
+            expect(prompt).toContain('funding_rounds: array');
+            expect(prompt).toContain('List of funding rounds');
+            expect(prompt).toContain('items (object)');
+            expect(prompt).toContain('round_type: string');
+            expect(prompt).toContain('seed, series_a, series_b');
+            expect(prompt).toContain('amount_usd: number (optional)');
+        });
+
+        it('should generate prompt for nested object', () => {
+            const schema: Schema = {
+                fields: {
+                    company: {
+                        type: 'object',
+                        description: 'Company information',
+                        properties: {
+                            name: { type: 'string' },
+                            employees: { type: 'integer', min: 1 },
+                        },
+                    },
+                },
+            };
+
+            const prompt = buildSystemPrompt(schema);
+
+            expect(prompt).toContain('company: object');
+            expect(prompt).toContain('Company information');
+            expect(prompt).toContain('name: string');
+            expect(prompt).toContain('employees: integer');
+        });
+    });
+});

--- a/src/core/__tests__/coercion.test.ts
+++ b/src/core/__tests__/coercion.test.ts
@@ -1,0 +1,678 @@
+/**
+ * Tests for type coercion module
+ */
+
+import { describe, it, expect } from 'vitest';
+import { coerceValue, coerceExtractedData, coerceEnumValue, coerceDateValue } from '../coercion.js';
+
+describe('Type Coercion', () => {
+    describe('coerceValue', () => {
+        describe('null-like strings', () => {
+            it('should coerce "null" string to null for optional fields', () => {
+                const result = coerceValue('null', 'number', 'amount', true);
+                expect(result.value).toBe(null);
+                expect(result.coerced).toBe(true);
+                expect(result.warning?.originalValue).toBe('null');
+                expect(result.warning?.coercedValue).toBe(null);
+            });
+
+            it('should coerce "N/A" string to null for optional fields', () => {
+                const result = coerceValue('N/A', 'string', 'name', true);
+                expect(result.value).toBe(null);
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce empty string to null for optional fields', () => {
+                const result = coerceValue('', 'number', 'count', true);
+                expect(result.value).toBe(null);
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce "none" string to null for optional fields', () => {
+                const result = coerceValue('none', 'string', 'value', true);
+                expect(result.value).toBe(null);
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce "undefined" string to null for optional fields', () => {
+                const result = coerceValue('undefined', 'boolean', 'flag', true);
+                expect(result.value).toBe(null);
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should NOT coerce null-like strings for required fields (let validation handle)', () => {
+                const result = coerceValue('null', 'number', 'amount', false);
+                // For required fields, it won't coerce to null but will try type coercion
+                // 'null' can't be parsed as number, so value remains unchanged
+                expect(result.value).toBe('null');
+                expect(result.coerced).toBe(false);
+            });
+        });
+
+        describe('number coercion', () => {
+            it('should not coerce actual numbers', () => {
+                const result = coerceValue(42, 'number', 'count', false);
+                expect(result.value).toBe(42);
+                expect(result.coerced).toBe(false);
+            });
+
+            it('should coerce string "123" to number 123', () => {
+                const result = coerceValue('123', 'number', 'count', false);
+                expect(result.value).toBe(123);
+                expect(result.coerced).toBe(true);
+                expect(result.warning?.message).toContain("Coerced string '123' to number 123");
+            });
+
+            it('should coerce string "1.5" to number 1.5', () => {
+                const result = coerceValue('1.5', 'number', 'price', false);
+                expect(result.value).toBe(1.5);
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce string "-42.5" to number -42.5', () => {
+                const result = coerceValue('-42.5', 'number', 'delta', false);
+                expect(result.value).toBe(-42.5);
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce boolean true to 1', () => {
+                const result = coerceValue(true, 'number', 'flag', false);
+                expect(result.value).toBe(1);
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce boolean false to 0', () => {
+                const result = coerceValue(false, 'number', 'flag', false);
+                expect(result.value).toBe(0);
+                expect(result.coerced).toBe(true);
+            });
+        });
+
+        describe('integer coercion', () => {
+            it('should not coerce actual integers', () => {
+                const result = coerceValue(42, 'integer', 'count', false);
+                expect(result.value).toBe(42);
+                expect(result.coerced).toBe(false);
+            });
+
+            it('should coerce string "123" to integer 123', () => {
+                const result = coerceValue('123', 'integer', 'count', false);
+                expect(result.value).toBe(123);
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should truncate float to integer', () => {
+                const result = coerceValue(3.7, 'integer', 'count', false);
+                expect(result.value).toBe(3);
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce string float to integer', () => {
+                const result = coerceValue('3.9', 'integer', 'count', false);
+                expect(result.value).toBe(3);
+                expect(result.coerced).toBe(true);
+            });
+        });
+
+        describe('boolean coercion', () => {
+            it('should not coerce actual booleans', () => {
+                const result = coerceValue(true, 'boolean', 'active', false);
+                expect(result.value).toBe(true);
+                expect(result.coerced).toBe(false);
+            });
+
+            it('should coerce string "true" to boolean true', () => {
+                const result = coerceValue('true', 'boolean', 'active', false);
+                expect(result.value).toBe(true);
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce string "false" to boolean false', () => {
+                const result = coerceValue('false', 'boolean', 'active', false);
+                expect(result.value).toBe(false);
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce string "yes" to boolean true', () => {
+                const result = coerceValue('yes', 'boolean', 'active', false);
+                expect(result.value).toBe(true);
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce string "no" to boolean false', () => {
+                const result = coerceValue('no', 'boolean', 'active', false);
+                expect(result.value).toBe(false);
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce string "1" to boolean true', () => {
+                const result = coerceValue('1', 'boolean', 'active', false);
+                expect(result.value).toBe(true);
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce string "0" to boolean false', () => {
+                const result = coerceValue('0', 'boolean', 'active', false);
+                expect(result.value).toBe(false);
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce number 1 to boolean true', () => {
+                const result = coerceValue(1, 'boolean', 'active', false);
+                expect(result.value).toBe(true);
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce number 0 to boolean false', () => {
+                const result = coerceValue(0, 'boolean', 'active', false);
+                expect(result.value).toBe(false);
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should be case-insensitive', () => {
+                expect(coerceValue('TRUE', 'boolean', 'active', false).value).toBe(true);
+                expect(coerceValue('False', 'boolean', 'active', false).value).toBe(false);
+                expect(coerceValue('YES', 'boolean', 'active', false).value).toBe(true);
+                expect(coerceValue('No', 'boolean', 'active', false).value).toBe(false);
+            });
+        });
+
+        describe('string coercion', () => {
+            it('should not coerce actual strings', () => {
+                const result = coerceValue('hello', 'string', 'name', false);
+                expect(result.value).toBe('hello');
+                expect(result.coerced).toBe(false);
+            });
+
+            it('should coerce number to string', () => {
+                const result = coerceValue(42, 'string', 'code', false);
+                expect(result.value).toBe('42');
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce boolean to string', () => {
+                const result = coerceValue(true, 'string', 'status', false);
+                expect(result.value).toBe('true');
+                expect(result.coerced).toBe(true);
+            });
+        });
+
+        describe('edge cases', () => {
+            it('should handle null value', () => {
+                const result = coerceValue(null, 'string', 'name', true);
+                expect(result.value).toBe(null);
+                expect(result.coerced).toBe(false);
+            });
+
+            it('should handle undefined value', () => {
+                const result = coerceValue(undefined, 'number', 'count', true);
+                expect(result.value).toBe(undefined);
+                expect(result.coerced).toBe(false);
+            });
+
+            it('should trim whitespace before coercion', () => {
+                const result = coerceValue('  123  ', 'number', 'count', false);
+                expect(result.value).toBe(123);
+                expect(result.coerced).toBe(true);
+            });
+        });
+    });
+
+    describe('coerceExtractedData', () => {
+        it('should coerce multiple fields', () => {
+            const data = {
+                name: 'John',
+                age: '30',
+                active: 'yes',
+            };
+            const fields = {
+                name: { type: 'string' as const },
+                age: { type: 'number' as const },
+                active: { type: 'boolean' as const },
+            };
+
+            const result = coerceExtractedData(data, fields);
+
+            expect(result.data.name).toBe('John');
+            expect(result.data.age).toBe(30);
+            expect(result.data.active).toBe(true);
+            expect(result.warnings).toHaveLength(2); // age and active were coerced
+        });
+
+        it('should coerce null strings to null for optional fields', () => {
+            const data = {
+                name: 'John',
+                amount: 'null',
+            };
+            const fields = {
+                name: { type: 'string' as const },
+                amount: { type: 'number' as const, optional: true },
+            };
+
+            const result = coerceExtractedData(data, fields);
+
+            expect(result.data.name).toBe('John');
+            expect(result.data.amount).toBe(null);
+            expect(result.warnings).toHaveLength(1);
+            expect(result.warnings[0].field).toBe('amount');
+        });
+
+        it('should preserve fields not in schema', () => {
+            const data = {
+                name: 'John',
+                extra: 'value',
+            };
+            const fields = {
+                name: { type: 'string' as const },
+            };
+
+            const result = coerceExtractedData(data, fields);
+
+            expect(result.data.name).toBe('John');
+            expect(result.data.extra).toBe('value');
+        });
+
+        it('should return empty warnings array when no coercion needed', () => {
+            const data = {
+                name: 'John',
+                age: 30,
+                active: true,
+            };
+            const fields = {
+                name: { type: 'string' as const },
+                age: { type: 'number' as const },
+                active: { type: 'boolean' as const },
+            };
+
+            const result = coerceExtractedData(data, fields);
+
+            expect(result.warnings).toHaveLength(0);
+        });
+    });
+
+    describe('enum coercion', () => {
+        it('should not coerce exact enum match', () => {
+            const data = { status: 'active' };
+            const fields = {
+                status: { 
+                    type: 'string' as const, 
+                    enum: ['active', 'inactive', 'pending'] 
+                },
+            };
+
+            const result = coerceExtractedData(data, fields);
+
+            expect(result.data.status).toBe('active');
+            expect(result.warnings).toHaveLength(0);
+        });
+
+        it('should coerce "Active" to "active" (case insensitive)', () => {
+            const data = { status: 'Active' };
+            const fields = {
+                status: { 
+                    type: 'string' as const, 
+                    enum: ['active', 'inactive', 'pending'] 
+                },
+            };
+
+            const result = coerceExtractedData(data, fields);
+
+            expect(result.data.status).toBe('active');
+            expect(result.warnings).toHaveLength(1);
+            expect(result.warnings[0].originalValue).toBe('Active');
+            expect(result.warnings[0].coercedValue).toBe('active');
+        });
+
+        it('should coerce "Series B" to "series_b" (spaces to underscores)', () => {
+            const data = { round_type: 'Series B' };
+            const fields = {
+                round_type: { 
+                    type: 'string' as const, 
+                    enum: ['pre_seed', 'seed', 'series_a', 'series_b', 'series_c'] 
+                },
+            };
+
+            const result = coerceExtractedData(data, fields);
+
+            expect(result.data.round_type).toBe('series_b');
+            expect(result.warnings).toHaveLength(1);
+            expect(result.warnings[0].message).toContain("Coerced enum value 'Series B' to 'series_b'");
+        });
+
+        it('should coerce "SERIES-A" to "series_a" (hyphens to underscores)', () => {
+            const data = { round_type: 'SERIES-A' };
+            const fields = {
+                round_type: { 
+                    type: 'string' as const, 
+                    enum: ['pre_seed', 'seed', 'series_a', 'series_b'] 
+                },
+            };
+
+            const result = coerceExtractedData(data, fields);
+
+            expect(result.data.round_type).toBe('series_a');
+            expect(result.warnings).toHaveLength(1);
+        });
+
+        it('should not coerce if no enum match found', () => {
+            const data = { status: 'unknown_value' };
+            const fields = {
+                status: { 
+                    type: 'string' as const, 
+                    enum: ['active', 'inactive'] 
+                },
+            };
+
+            const result = coerceExtractedData(data, fields);
+
+            // Value unchanged, validation will catch it
+            expect(result.data.status).toBe('unknown_value');
+            expect(result.warnings).toHaveLength(0);
+        });
+    });
+
+    describe('recursive array coercion', () => {
+        it('should coerce values inside array items', () => {
+            const data = {
+                items: [
+                    { name: 'Item 1', price: '10.50' },
+                    { name: 'Item 2', price: '20.00' },
+                ],
+            };
+            const fields = {
+                items: {
+                    type: 'array' as const,
+                    items: {
+                        type: 'object' as const,
+                        properties: {
+                            name: { type: 'string' as const },
+                            price: { type: 'number' as const },
+                        },
+                    },
+                },
+            };
+
+            const result = coerceExtractedData(data, fields);
+            const items = result.data.items as Array<{ name: string; price: number }>;
+
+            expect(items[0].price).toBe(10.50);
+            expect(items[1].price).toBe(20.00);
+            expect(result.warnings).toHaveLength(2);
+            expect(result.warnings[0].field).toBe('items[0].price');
+            expect(result.warnings[1].field).toBe('items[1].price');
+        });
+
+        it('should coerce enum values inside array items', () => {
+            const data = {
+                funding_rounds: [
+                    { round_type: 'Seed', amount: 1000000 },
+                    { round_type: 'Series A', amount: 5000000 },
+                    { round_type: 'Series B', amount: 20000000 },
+                ],
+            };
+            const fields = {
+                funding_rounds: {
+                    type: 'array' as const,
+                    items: {
+                        type: 'object' as const,
+                        properties: {
+                            round_type: { 
+                                type: 'string' as const,
+                                enum: ['pre_seed', 'seed', 'series_a', 'series_b', 'series_c']
+                            },
+                            amount: { type: 'number' as const },
+                        },
+                    },
+                },
+            };
+
+            const result = coerceExtractedData(data, fields);
+            const rounds = result.data.funding_rounds as Array<{ round_type: string; amount: number }>;
+
+            expect(rounds[0].round_type).toBe('seed');
+            expect(rounds[1].round_type).toBe('series_a');
+            expect(rounds[2].round_type).toBe('series_b');
+            expect(result.warnings).toHaveLength(3);
+        });
+
+        it('should handle nested null values in arrays', () => {
+            const data = {
+                items: [
+                    { name: 'Item 1', price: null },
+                    { name: 'Item 2', price: 20.00 },
+                ],
+            };
+            const fields = {
+                items: {
+                    type: 'array' as const,
+                    items: {
+                        type: 'object' as const,
+                        properties: {
+                            name: { type: 'string' as const },
+                            price: { type: 'number' as const, optional: true },
+                        },
+                    },
+                },
+            };
+
+            const result = coerceExtractedData(data, fields);
+            const items = result.data.items as Array<{ name: string; price: number | null }>;
+
+            expect(items[0].price).toBe(null);
+            expect(items[1].price).toBe(20.00);
+            expect(result.warnings).toHaveLength(0);
+        });
+    });
+
+    describe('recursive object coercion', () => {
+        it('should coerce values inside nested objects', () => {
+            const data = {
+                address: {
+                    city: 'New York',
+                    zip: '10001',
+                },
+            };
+            const fields = {
+                address: {
+                    type: 'object' as const,
+                    properties: {
+                        city: { type: 'string' as const },
+                        zip: { type: 'integer' as const },
+                    },
+                },
+            };
+
+            const result = coerceExtractedData(data, fields);
+            const address = result.data.address as { city: string; zip: number };
+
+            expect(address.city).toBe('New York');
+            expect(address.zip).toBe(10001);
+            expect(result.warnings).toHaveLength(1);
+            expect(result.warnings[0].field).toBe('address.zip');
+        });
+
+        it('should coerce enum values inside nested objects', () => {
+            const data = {
+                investor: {
+                    name: 'Sequoia',
+                    type: 'Venture Capital',
+                },
+            };
+            const fields = {
+                investor: {
+                    type: 'object' as const,
+                    properties: {
+                        name: { type: 'string' as const },
+                        type: { 
+                            type: 'string' as const,
+                            enum: ['vc', 'angel', 'corporate', 'venture_capital']
+                        },
+                    },
+                },
+            };
+
+            const result = coerceExtractedData(data, fields);
+            const investor = result.data.investor as { name: string; type: string };
+
+            expect(investor.name).toBe('Sequoia');
+            expect(investor.type).toBe('venture_capital');
+            expect(result.warnings).toHaveLength(1);
+            expect(result.warnings[0].field).toBe('investor.type');
+        });
+    });
+
+    describe('date coercion', () => {
+        describe('coerceDateValue', () => {
+            it('should not coerce already ISO format dates', () => {
+                const result = coerceDateValue('2024-11-20', 'date_field');
+                expect(result.value).toBe('2024-11-20');
+                expect(result.coerced).toBe(false);
+            });
+
+            it('should coerce US format MM/DD/YYYY to ISO', () => {
+                const result = coerceDateValue('11/20/2024', 'date_field');
+                expect(result.value).toBe('2024-11-20');
+                expect(result.coerced).toBe(true);
+                expect(result.warning?.message).toContain("Coerced date '11/20/2024' to ISO format '2024-11-20'");
+            });
+
+            it('should coerce short year format MM/DD/YY to ISO', () => {
+                const result = coerceDateValue('11/20/24', 'date_field');
+                expect(result.value).toBe('2024-11-20');
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce short year in 1900s (MM/DD/YY where YY >= 50)', () => {
+                const result = coerceDateValue('11/20/99', 'date_field');
+                expect(result.value).toBe('1999-11-20');
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce European format DD-MM-YYYY to ISO', () => {
+                const result = coerceDateValue('20-11-2024', 'date_field');
+                expect(result.value).toBe('2024-11-20');
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce European format DD.MM.YYYY to ISO', () => {
+                const result = coerceDateValue('20.11.2024', 'date_field');
+                expect(result.value).toBe('2024-11-20');
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce written format "January 15, 2024" to ISO', () => {
+                const result = coerceDateValue('January 15, 2024', 'date_field');
+                expect(result.value).toBe('2024-01-15');
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce abbreviated month "Jan 15, 2024" to ISO', () => {
+                const result = coerceDateValue('Jan 15, 2024', 'date_field');
+                expect(result.value).toBe('2024-01-15');
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should coerce "15 January 2024" format to ISO', () => {
+                const result = coerceDateValue('15 January 2024', 'date_field');
+                expect(result.value).toBe('2024-01-15');
+                expect(result.coerced).toBe(true);
+            });
+
+            it('should strip time from ISO datetime and normalize', () => {
+                const result = coerceDateValue('2025-01-25T10:00:00', 'date_field');
+                expect(result.value).toBe('2025-01-25');
+                expect(result.coerced).toBe(false); // Starts with ISO date, just stripped
+            });
+
+            it('should not coerce invalid date string', () => {
+                const result = coerceDateValue('not a date', 'date_field');
+                expect(result.value).toBe('not a date');
+                expect(result.coerced).toBe(false);
+            });
+
+            it('should not coerce out-of-range dates', () => {
+                const result = coerceDateValue('13/45/2024', 'date_field');
+                // Month 13, day 45 is invalid
+                expect(result.coerced).toBe(false);
+            });
+        });
+
+        describe('date coercion in coerceExtractedData', () => {
+            it('should coerce date fields with format="date"', () => {
+                const data = {
+                    event_date: '11/20/24',
+                    name: 'Test Event',
+                };
+                const fields = {
+                    event_date: { type: 'string' as const, format: 'date' },
+                    name: { type: 'string' as const },
+                };
+
+                const result = coerceExtractedData(data, fields);
+
+                expect(result.data.event_date).toBe('2024-11-20');
+                expect(result.data.name).toBe('Test Event');
+                expect(result.warnings).toHaveLength(1);
+                expect(result.warnings[0].field).toBe('event_date');
+            });
+
+            it('should coerce date fields with format="date-time"', () => {
+                const data = {
+                    timestamp: 'Jan 15, 2024',
+                };
+                const fields = {
+                    timestamp: { type: 'string' as const, format: 'date-time' },
+                };
+
+                const result = coerceExtractedData(data, fields);
+
+                expect(result.data.timestamp).toBe('2024-01-15');
+                expect(result.warnings).toHaveLength(1);
+            });
+
+            it('should coerce dates inside array items', () => {
+                const data = {
+                    events: [
+                        { name: 'Event 1', date: '11/20/24' },
+                        { name: 'Event 2', date: 'January 15, 2025' },
+                    ],
+                };
+                const fields = {
+                    events: {
+                        type: 'array' as const,
+                        items: {
+                            type: 'object' as const,
+                            properties: {
+                                name: { type: 'string' as const },
+                                date: { type: 'string' as const, format: 'date' },
+                            },
+                        },
+                    },
+                };
+
+                const result = coerceExtractedData(data, fields);
+                const events = result.data.events as Array<{ name: string; date: string }>;
+
+                expect(events[0].date).toBe('2024-11-20');
+                expect(events[1].date).toBe('2025-01-15');
+                expect(result.warnings).toHaveLength(2);
+                expect(result.warnings[0].field).toBe('events[0].date');
+                expect(result.warnings[1].field).toBe('events[1].date');
+            });
+
+            it('should not coerce string fields without date format', () => {
+                const data = {
+                    description: '11/20/24', // Looks like a date but no format specified
+                };
+                const fields = {
+                    description: { type: 'string' as const },
+                };
+
+                const result = coerceExtractedData(data, fields);
+
+                expect(result.data.description).toBe('11/20/24');
+                expect(result.warnings).toHaveLength(0);
+            });
+        });
+    });
+});

--- a/src/core/coercion.ts
+++ b/src/core/coercion.ts
@@ -1,0 +1,566 @@
+/**
+ * Type coercion module - converts LLM output to expected types
+ * 
+ * Handles common LLM quirks like:
+ * - String "null" instead of null
+ * - String numbers like "123" instead of 123
+ * - String booleans like "true" instead of true
+ * - Enum case mismatch like "Series A" instead of "series_a"
+ * - Date format variations like "11/20/24" instead of "2024-11-20"
+ */
+
+import type { FieldType, FieldDefinition, ArrayItemDefinition } from '../schemas/types.js';
+
+/**
+ * Warning generated during coercion
+ */
+export interface CoercionWarning {
+    field: string;
+    message: string;
+    originalValue: unknown;
+    coercedValue: unknown;
+}
+
+/**
+ * Result of coercing a value
+ */
+export interface CoercionResult {
+    value: unknown;
+    coerced: boolean;
+    warning?: CoercionWarning;
+}
+
+/**
+ * Null-like string values that should be coerced to null
+ */
+const NULL_STRINGS = new Set(['null', 'none', 'n/a', 'na', 'undefined', '']);
+
+/**
+ * Boolean true string values
+ */
+const TRUE_STRINGS = new Set(['true', 'yes', '1']);
+
+/**
+ * Boolean false string values
+ */
+const FALSE_STRINGS = new Set(['false', 'no', '0']);
+
+/**
+ * Normalize a string for enum matching
+ * Converts to lowercase and replaces spaces/hyphens with underscores
+ */
+function normalizeEnumValue(value: string): string {
+    return value.trim().toLowerCase().replace(/[\s-]+/g, '_');
+}
+
+/**
+ * Coerce an enum value to match expected enum values (case-insensitive)
+ * 
+ * @param value - The string value to coerce
+ * @param enumValues - Array of allowed enum values
+ * @param fieldName - Field name for warning messages
+ * @returns CoercionResult with matched enum value or original if no match
+ */
+export function coerceEnumValue(
+    value: string,
+    enumValues: string[],
+    fieldName: string
+): CoercionResult {
+    // Exact match - no coercion needed
+    if (enumValues.includes(value)) {
+        return { value, coerced: false };
+    }
+
+    // Try normalized match
+    const normalized = normalizeEnumValue(value);
+    const match = enumValues.find(e => normalizeEnumValue(e) === normalized);
+    
+    if (match) {
+        return {
+            value: match,
+            coerced: true,
+            warning: {
+                field: fieldName,
+                message: `Coerced enum value '${value}' to '${match}'`,
+                originalValue: value,
+                coercedValue: match,
+            },
+        };
+    }
+
+    // No match found - return original (validation will catch it)
+    return { value, coerced: false };
+}
+
+/**
+ * Common date format patterns and their parsing logic
+ * Supports: MM/DD/YY, MM/DD/YYYY, DD-MM-YYYY, YYYY-MM-DD, etc.
+ */
+const DATE_PATTERNS: Array<{
+    regex: RegExp;
+    parse: (match: RegExpMatchArray) => { year: number; month: number; day: number } | null;
+}> = [
+    // ISO format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS
+    {
+        regex: /^(\d{4})-(\d{1,2})-(\d{1,2})(?:T[\d:]+)?$/,
+        parse: (m) => ({ year: parseInt(m[1]), month: parseInt(m[2]), day: parseInt(m[3]) }),
+    },
+    // US format: MM/DD/YYYY or MM/DD/YY
+    {
+        regex: /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/,
+        parse: (m) => {
+            let year = parseInt(m[3]);
+            if (year < 100) year += year < 50 ? 2000 : 1900;
+            return { year, month: parseInt(m[1]), day: parseInt(m[2]) };
+        },
+    },
+    // European format: DD-MM-YYYY or DD.MM.YYYY
+    {
+        regex: /^(\d{1,2})[-.](\d{1,2})[-.](\d{4})$/,
+        parse: (m) => ({ year: parseInt(m[3]), month: parseInt(m[2]), day: parseInt(m[1]) }),
+    },
+    // Written format: January 15, 2024 or Jan 15, 2024
+    {
+        regex: /^([A-Za-z]+)\s+(\d{1,2}),?\s+(\d{4})$/,
+        parse: (m) => {
+            const monthNames: Record<string, number> = {
+                january: 1, jan: 1, february: 2, feb: 2, march: 3, mar: 3,
+                april: 4, apr: 4, may: 5, june: 6, jun: 6,
+                july: 7, jul: 7, august: 8, aug: 8, september: 9, sep: 9, sept: 9,
+                october: 10, oct: 10, november: 11, nov: 11, december: 12, dec: 12,
+            };
+            const month = monthNames[m[1].toLowerCase()];
+            if (!month) return null;
+            return { year: parseInt(m[3]), month, day: parseInt(m[2]) };
+        },
+    },
+    // Written format: 15 January 2024 or 15 Jan 2024
+    {
+        regex: /^(\d{1,2})\s+([A-Za-z]+)\s+(\d{4})$/,
+        parse: (m) => {
+            const monthNames: Record<string, number> = {
+                january: 1, jan: 1, february: 2, feb: 2, march: 3, mar: 3,
+                april: 4, apr: 4, may: 5, june: 6, jun: 6,
+                july: 7, jul: 7, august: 8, aug: 8, september: 9, sep: 9, sept: 9,
+                october: 10, oct: 10, november: 11, nov: 11, december: 12, dec: 12,
+            };
+            const month = monthNames[m[2].toLowerCase()];
+            if (!month) return null;
+            return { year: parseInt(m[3]), month, day: parseInt(m[1]) };
+        },
+    },
+];
+
+/**
+ * Coerce a date string to ISO format (YYYY-MM-DD)
+ * 
+ * @param value - The date string to coerce
+ * @param fieldName - Field name for warning messages
+ * @returns CoercionResult with ISO date or original if not parseable
+ */
+export function coerceDateValue(
+    value: string,
+    fieldName: string
+): CoercionResult {
+    const trimmed = value.trim();
+    
+    // Already in ISO format without time - no coercion needed
+    if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+        return { value: trimmed, coerced: false };
+    }
+
+    // Try each pattern
+    for (const pattern of DATE_PATTERNS) {
+        const match = trimmed.match(pattern.regex);
+        if (match) {
+            const parsed = pattern.parse(match);
+            if (parsed) {
+                // Validate the date components
+                if (parsed.month >= 1 && parsed.month <= 12 && 
+                    parsed.day >= 1 && parsed.day <= 31 &&
+                    parsed.year >= 1900 && parsed.year <= 2100) {
+                    
+                    const isoDate = `${parsed.year}-${String(parsed.month).padStart(2, '0')}-${String(parsed.day).padStart(2, '0')}`;
+                    
+                    // Check if it's different from original (ignoring time component)
+                    if (isoDate !== trimmed && !trimmed.startsWith(isoDate)) {
+                        return {
+                            value: isoDate,
+                            coerced: true,
+                            warning: {
+                                field: fieldName,
+                                message: `Coerced date '${value}' to ISO format '${isoDate}'`,
+                                originalValue: value,
+                                coercedValue: isoDate,
+                            },
+                        };
+                    }
+                    
+                    return { value: isoDate, coerced: false };
+                }
+            }
+        }
+    }
+
+    // No pattern matched - return original
+    return { value, coerced: false };
+}
+
+/**
+ * Coerce a value to the expected type
+ * 
+ * @param value - The value to coerce
+ * @param targetType - The expected field type
+ * @param fieldName - Field name for warning messages
+ * @param isOptional - Whether the field is optional (affects null coercion)
+ * @returns CoercionResult with the coerced value and any warnings
+ */
+export function coerceValue(
+    value: unknown,
+    targetType: FieldType,
+    fieldName: string,
+    isOptional: boolean = false
+): CoercionResult {
+    // Already null/undefined - no coercion needed
+    if (value === null || value === undefined) {
+        return { value, coerced: false };
+    }
+
+    // Check for null-like strings first (applies to all types)
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        if (NULL_STRINGS.has(normalized)) {
+            // Only coerce to null if field is optional
+            if (isOptional) {
+                return {
+                    value: null,
+                    coerced: true,
+                    warning: {
+                        field: fieldName,
+                        message: `Coerced '${value}' string to null`,
+                        originalValue: value,
+                        coercedValue: null,
+                    },
+                };
+            }
+            // For required fields, try type-specific coercion below
+        }
+    }
+
+    switch (targetType) {
+        case 'number':
+            return coerceToNumber(value, fieldName);
+        case 'integer':
+            return coerceToInteger(value, fieldName);
+        case 'boolean':
+            return coerceToBoolean(value, fieldName);
+        case 'string':
+            return coerceToString(value, fieldName);
+        default:
+            return { value, coerced: false };
+    }
+}
+
+/**
+ * Coerce value to number
+ */
+function coerceToNumber(value: unknown, fieldName: string): CoercionResult {
+    // Already a number
+    if (typeof value === 'number') {
+        return { value, coerced: false };
+    }
+
+    // String to number
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        
+        // Handle empty or null-like strings
+        if (NULL_STRINGS.has(trimmed.toLowerCase())) {
+            return { value, coerced: false }; // Let validation handle it
+        }
+
+        // Try to parse as number
+        const parsed = parseFloat(trimmed);
+        if (!isNaN(parsed)) {
+            return {
+                value: parsed,
+                coerced: true,
+                warning: {
+                    field: fieldName,
+                    message: `Coerced string '${value}' to number ${parsed}`,
+                    originalValue: value,
+                    coercedValue: parsed,
+                },
+            };
+        }
+    }
+
+    // Boolean to number
+    if (typeof value === 'boolean') {
+        const num = value ? 1 : 0;
+        return {
+            value: num,
+            coerced: true,
+            warning: {
+                field: fieldName,
+                message: `Coerced boolean ${value} to number ${num}`,
+                originalValue: value,
+                coercedValue: num,
+            },
+        };
+    }
+
+    return { value, coerced: false };
+}
+
+/**
+ * Coerce value to integer
+ */
+function coerceToInteger(value: unknown, fieldName: string): CoercionResult {
+    // First coerce to number
+    const numberResult = coerceToNumber(value, fieldName);
+    
+    if (typeof numberResult.value === 'number') {
+        // If it's already an integer, keep as-is
+        if (Number.isInteger(numberResult.value)) {
+            return numberResult;
+        }
+        
+        // Truncate to integer
+        const intValue = Math.trunc(numberResult.value);
+        return {
+            value: intValue,
+            coerced: true,
+            warning: {
+                field: fieldName,
+                message: `Coerced ${value} to integer ${intValue}`,
+                originalValue: value,
+                coercedValue: intValue,
+            },
+        };
+    }
+
+    return { value, coerced: false };
+}
+
+/**
+ * Coerce value to boolean
+ */
+function coerceToBoolean(value: unknown, fieldName: string): CoercionResult {
+    // Already a boolean
+    if (typeof value === 'boolean') {
+        return { value, coerced: false };
+    }
+
+    // String to boolean
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        
+        if (TRUE_STRINGS.has(normalized)) {
+            return {
+                value: true,
+                coerced: true,
+                warning: {
+                    field: fieldName,
+                    message: `Coerced string '${value}' to boolean true`,
+                    originalValue: value,
+                    coercedValue: true,
+                },
+            };
+        }
+        
+        if (FALSE_STRINGS.has(normalized)) {
+            return {
+                value: false,
+                coerced: true,
+                warning: {
+                    field: fieldName,
+                    message: `Coerced string '${value}' to boolean false`,
+                    originalValue: value,
+                    coercedValue: false,
+                },
+            };
+        }
+    }
+
+    // Number to boolean
+    if (typeof value === 'number') {
+        const boolValue = value !== 0;
+        return {
+            value: boolValue,
+            coerced: true,
+            warning: {
+                field: fieldName,
+                message: `Coerced number ${value} to boolean ${boolValue}`,
+                originalValue: value,
+                coercedValue: boolValue,
+            },
+        };
+    }
+
+    return { value, coerced: false };
+}
+
+/**
+ * Coerce value to string
+ */
+function coerceToString(value: unknown, fieldName: string): CoercionResult {
+    // Already a string
+    if (typeof value === 'string') {
+        return { value, coerced: false };
+    }
+
+    // Number or boolean to string
+    if (typeof value === 'number' || typeof value === 'boolean') {
+        const strValue = String(value);
+        return {
+            value: strValue,
+            coerced: true,
+            warning: {
+                field: fieldName,
+                message: `Coerced ${typeof value} ${value} to string '${strValue}'`,
+                originalValue: value,
+                coercedValue: strValue,
+            },
+        };
+    }
+
+    return { value, coerced: false };
+}
+
+/**
+ * Coerce all values in an extracted data object (recursive)
+ * 
+ * Handles:
+ * - Top-level field coercion
+ * - Enum value normalization (case-insensitive)
+ * - Recursive coercion for array items
+ * - Recursive coercion for nested objects
+ * 
+ * @param data - The extracted data object
+ * @param fields - Field definitions from schema
+ * @returns Coerced data and any warnings generated
+ */
+export function coerceExtractedData(
+    data: Record<string, unknown>,
+    fields: Record<string, FieldDefinition>
+): { data: Record<string, unknown>; warnings: CoercionWarning[] } {
+    const coercedData: Record<string, unknown> = { ...data };
+    const warnings: CoercionWarning[] = [];
+
+    for (const [fieldName, fieldDef] of Object.entries(fields)) {
+        if (!(fieldName in data)) continue;
+        
+        const value = data[fieldName];
+        
+        // Handle null/undefined - no coercion needed
+        if (value === null || value === undefined) {
+            coercedData[fieldName] = value;
+            continue;
+        }
+
+        // Handle array type - recursively coerce items
+        if (fieldDef.type === 'array' && Array.isArray(value) && fieldDef.items) {
+            const { array: coercedArray, warnings: arrayWarnings } = coerceArrayItems(
+                value,
+                fieldDef.items,
+                fieldName
+            );
+            coercedData[fieldName] = coercedArray;
+            warnings.push(...arrayWarnings);
+            continue;
+        }
+
+        // Handle object type - recursively coerce properties
+        if (fieldDef.type === 'object' && typeof value === 'object' && !Array.isArray(value) && fieldDef.properties) {
+            const { data: coercedObj, warnings: objWarnings } = coerceExtractedData(
+                value as Record<string, unknown>,
+                fieldDef.properties
+            );
+            // Update warning field paths
+            for (const w of objWarnings) {
+                w.field = `${fieldName}.${w.field}`;
+            }
+            coercedData[fieldName] = coercedObj;
+            warnings.push(...objWarnings);
+            continue;
+        }
+
+        // Handle string with enum - try enum coercion first
+        if (fieldDef.type === 'string' && typeof value === 'string' && fieldDef.enum) {
+            const enumResult = coerceEnumValue(value, fieldDef.enum, fieldName);
+            coercedData[fieldName] = enumResult.value;
+            if (enumResult.warning) {
+                warnings.push(enumResult.warning);
+            }
+            continue;
+        }
+
+        // Handle string with date/date-time format - normalize to ISO
+        if (fieldDef.type === 'string' && typeof value === 'string' && 
+            (fieldDef.format === 'date' || fieldDef.format === 'date-time')) {
+            const dateResult = coerceDateValue(value, fieldName);
+            coercedData[fieldName] = dateResult.value;
+            if (dateResult.warning) {
+                warnings.push(dateResult.warning);
+            }
+            continue;
+        }
+
+        // Standard type coercion
+        const result = coerceValue(
+            value,
+            fieldDef.type,
+            fieldName,
+            fieldDef.optional ?? false
+        );
+        
+        coercedData[fieldName] = result.value;
+        if (result.warning) {
+            warnings.push(result.warning);
+        }
+    }
+
+    return { data: coercedData, warnings };
+}
+
+/**
+ * Coerce array items recursively
+ * 
+ * @param array - The array to coerce
+ * @param itemDef - Definition of array items
+ * @param fieldName - Parent field name for error paths
+ * @returns Coerced array and any warnings
+ */
+function coerceArrayItems(
+    array: unknown[],
+    itemDef: ArrayItemDefinition,
+    fieldName: string
+): { array: unknown[]; warnings: CoercionWarning[] } {
+    const coercedArray: unknown[] = [];
+    const warnings: CoercionWarning[] = [];
+
+    for (let i = 0; i < array.length; i++) {
+        const item = array[i];
+        const itemPath = `${fieldName}[${i}]`;
+
+        // Only handle object items for now (as per ArrayItemDefinition)
+        if (itemDef.type === 'object' && typeof item === 'object' && item !== null && !Array.isArray(item) && itemDef.properties) {
+            const { data: coercedItem, warnings: itemWarnings } = coerceExtractedData(
+                item as Record<string, unknown>,
+                itemDef.properties
+            );
+            // Update warning field paths
+            for (const w of itemWarnings) {
+                w.field = `${itemPath}.${w.field}`;
+            }
+            coercedArray.push(coercedItem);
+            warnings.push(...itemWarnings);
+        } else {
+            // Non-object items are passed through as-is
+            coercedArray.push(item);
+        }
+    }
+
+    return { array: coercedArray, warnings };
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,6 +4,7 @@
 
 export { ExtractionPipeline, extract } from './pipeline.js';
 export { validateExtractedData } from './validator.js';
+export { coerceValue, coerceExtractedData, coerceEnumValue, coerceDateValue } from './coercion.js';
 export { PipelineError, PipelineErrorCodes } from './errors.js';
 export {
     stripHtml,
@@ -20,3 +21,4 @@ export type {
     HtmlStripOptions,
     PreprocessingConfig,
 } from './types.js';
+export type { CoercionWarning, CoercionResult } from './coercion.js';

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -77,6 +77,12 @@ export interface PipelineResult {
         code: string;
         details?: Record<string, unknown>; // Original error details for formatting
     }>;
+    warnings?: Array<{
+        field: string;
+        message: string;
+        originalValue: unknown;
+        coercedValue: unknown;
+    }>;
     steps?: StepResult[];
     metadata: {
         duration: number;

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -96,6 +96,11 @@ export class LLMClient {
             max_tokens: this.config.maxTokens,
         };
 
+        // Add Ollama-specific options if configured
+        if (this.config.ollamaOptions) {
+            request.options = this.config.ollamaOptions;
+        }
+
         // Call API with retries
         const response = await this.chatWithRetry(request);
 

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -47,6 +47,15 @@ export interface LLMConfig {
     debugTokens?: boolean;
     /** Enable verbose debug output (shows full request/response) */
     debug?: boolean;
+    /** Ollama-specific options (e.g., num_ctx for context window) */
+    ollamaOptions?: {
+        /** Context window size in tokens (default varies by model) */
+        num_ctx?: number;
+        /** Number of tokens to keep from the prompt (default: 4) */
+        num_keep?: number;
+        /** Number of layers to run on GPU (-1 = all, 0 = none) */
+        num_gpu?: number;
+    };
 }
 
 /**
@@ -65,6 +74,12 @@ export interface LLMRequest {
     messages: ChatMessage[];
     temperature?: number;
     max_tokens?: number;
+    /** Ollama-specific options (passed through on Ollama endpoints) */
+    options?: {
+        num_ctx?: number;
+        num_keep?: number;
+        num_gpu?: number;
+    };
 }
 
 /**

--- a/src/schemas/__tests__/integration.test.ts
+++ b/src/schemas/__tests__/integration.test.ts
@@ -121,7 +121,7 @@ describe('Schema System Integration', () => {
                 expect(err.message).toContain('text');
                 expect(err.field).toBe('name');
                 expect(err.code).toBe(ErrorCodes.INVALID_FIELD_TYPE);
-                expect(err.details?.validTypes).toEqual(['string', 'number', 'integer', 'boolean']);
+                expect(err.details?.validTypes).toEqual(['string', 'number', 'integer', 'boolean', 'array', 'object']);
             }
         });
 

--- a/src/schemas/types.ts
+++ b/src/schemas/types.ts
@@ -8,7 +8,22 @@
  * Supported field types in schema definitions
  * Note: For dates, use type='string' with format='date-time'
  */
-export type FieldType = 'string' | 'number' | 'integer' | 'boolean';
+export type FieldType = 'string' | 'number' | 'integer' | 'boolean' | 'array' | 'object';
+
+/**
+ * Object field properties (for nested objects)
+ */
+export interface ObjectProperties {
+    [key: string]: FieldDefinition;
+}
+
+/**
+ * Array items definition
+ */
+export interface ArrayItemDefinition {
+    type: 'object';
+    properties: ObjectProperties;
+}
 
 /**
  * Field definition within a schema
@@ -22,6 +37,10 @@ export interface FieldDefinition {
     min?: number;
     max?: number;
     pattern?: string;
+    /** For array type: definition of array items */
+    items?: ArrayItemDefinition;
+    /** For object type: nested properties */
+    properties?: ObjectProperties;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements #70 (array-of-objects) and #71 (type coercion).

## Changes

### Type Coercion
- String to number/integer/boolean coercion
- Null-like string handling ("null", "none", "n/a" → null for optional fields)
- Coercion warnings in pipeline results for transparency
- New exports: `coerceValue()`, `coerceExtractedData()`, `coerceEnumValue()`, `coerceDateValue()`

### Enum Coercion
- Case-insensitive enum matching ("Series B" → "series_b")
- Space/hyphen to underscore normalization

### Date Coercion
- US format: "11/20/24" → "2024-11-20"
- European format: "20-11-2024" → "2024-11-20"
- Written format: "January 15, 2024" → "2024-01-15"
- Requires `format: "date"` or `format: "date-time"` in schema

### Array of Objects
- New field type: `type: "array"` with `items: { type: "object", properties: {...} }`
- New field type: `type: "object"` with `properties: {...}` for nested objects
- Recursive validation with proper error paths (e.g., "items[1].price")
- Recursive coercion for nested field values
- Prompt builder generates nested schema descriptions for LLMs

### Ollama Runtime Options
- `ollamaOptions.num_ctx` for dynamic context window sizing
- `ollamaOptions.num_gpu` for GPU layer control
- Pass Ollama-specific parameters without custom Modelfiles

### Benchmark Improvements
- Deep equality for array/object comparisons
- Full JSON display instead of "[object Object]"
- Model-specific config support (e.g., 32k context for deepseek-r1:14b)

## Testing
- 332 tests passing (26 new tests)
- Benchmarked on 5 models with 8 examples
- Date coercion fixed medical example accuracy

Closes #70, closes #71