### PR TITLE
chore: release v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ordis-dev/ordis",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ordis-dev/ordis",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "node-html-parser": "^7.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordis-dev/ordis",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "description": "Schema-first LLM extraction tool that turns unstructured text into validated structured data",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.5.0

Bumps version to 0.5.0 for npm publish.

See [CHANGELOG.md](https://github.com/ordis-dev/ordis/blob/release/0.5.0/CHANGELOG.md#050---2026-01-12) for full details.

### Highlights
- Type coercion for LLM output (#71)
- Enum case-insensitive coercion
- Date format normalization  
- Array of objects support (#70)
- Ollama runtime options (num_ctx, num_gpu)
- 332 tests passing