### PR TITLE
release: v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-01-14
+
+### Fixed
+- **JSON mode with Ollama /v1 endpoint** ([#81](https://github.com/ordis-dev/ordis/issues/81), [#82](https://github.com/ordis-dev/ordis/pull/82))
+  - Ollama's OpenAI-compatible `/v1/chat/completions` endpoint now correctly uses `response_format` instead of `format`
+  - Native `/api/chat` endpoint continues to use `format: "json"`
+  - Automatic endpoint detection - no user configuration needed
+  - Fixes issue where `/v1` endpoint with `format` parameter returned markdown-wrapped JSON
+
+### Documentation
+- Added clear comparison of Ollama `/v1` vs `/api` endpoints
+- Recommended `/v1` endpoint for portability across providers
+- Explained when to use each endpoint type
+
 ## [0.6.0] - 2026-01-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -264,6 +264,11 @@ npm run benchmark
 
 ## Roadmap
 
+**Completed in v0.6.1:**
+- ✅ Fixed JSON mode with Ollama /v1 endpoint ([#81](https://github.com/ordis-dev/ordis/issues/81))
+  - Automatic endpoint detection (response_format for /v1, format for /api)
+  - Improved documentation with endpoint comparison and recommendations
+
 **Completed in v0.6.0:**
 - ✅ JSON mode support for OpenAI and Ollama providers ([#78](https://github.com/ordis-dev/ordis/issues/78))
   - Auto-detection based on base URL

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ordis-dev/ordis",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ordis-dev/ordis",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "node-html-parser": "^7.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ordis-dev/ordis",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "description": "Schema-first LLM extraction tool that turns unstructured text into validated structured data",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.6.1

Bugfix release for Ollama /v1 endpoint JSON mode.

### Fixed

**JSON mode with Ollama /v1 endpoint** ([#81](https://github.com/ordis-dev/ordis/issues/81), [#82](https://github.com/ordis-dev/ordis/pull/82))
- Ollama OpenAI-compatible /v1/chat/completions endpoint now correctly uses response_format
- Native /api/chat endpoint continues to use format: "json"
- Automatic endpoint detection - no user configuration needed
- Fixes markdown-wrapped JSON responses when using /v1 endpoint

### Documentation
- Added clear comparison of Ollama /v1 vs /api endpoints
- Recommended /v1 endpoint for portability across providers
- Explained when to use each endpoint type

### Testing

All 338 tests pass
Build successful
Ready for npm publish (requires authentication)

### Files Changed

- src/llm/client.ts: Endpoint detection logic
- docs/json-mode.md: Enhanced endpoint documentation
- README.md: Updated roadmap
- CHANGELOG.md: Added v0.6.1 entry
- package.json: Version bumped to 0.6.1
